### PR TITLE
[25.03.05] 본사 메뉴 관리 수정 및 단종 기능 추가

### DIFF
--- a/CafeSync-FinalProject/src/main/java/com/ohgiraffers/cafesyncfinalproject/menu/controller/MenuController.java
+++ b/CafeSync-FinalProject/src/main/java/com/ohgiraffers/cafesyncfinalproject/menu/controller/MenuController.java
@@ -79,6 +79,9 @@ public class MenuController {
     @PutMapping("/hq/menus/{menuCode}")
     public ResponseEntity<ResponseDTO> modifyMenu(@PathVariable int menuCode, @RequestBody MenuDTO menuDTO) {
 
+        System.out.println("프론트에서 받은 메뉴코드 = " + menuCode);
+        System.out.println("단종 데이터 확인 = " + menuDTO);
+
         MenuDTO menuData = menuService.modifyMenu(menuDTO);
 
         return ResponseEntity.ok(new ResponseDTO(HttpStatus.OK,"메뉴 수정 성공", menuData));

--- a/CafeSync-FinalProject/src/main/java/com/ohgiraffers/cafesyncfinalproject/menu/model/dao/MenuRepository.java
+++ b/CafeSync-FinalProject/src/main/java/com/ohgiraffers/cafesyncfinalproject/menu/model/dao/MenuRepository.java
@@ -10,9 +10,10 @@ public interface MenuRepository extends JpaRepository<Menu, Integer> {
     List<Menu> findByCategoryCode(int categoryCode);
 
     @Query(
-        value="select m from Menu m where m.categoryCode =:categoryCode and m.menuNameKo like %:query%"
+            value = "select m from Menu m where m.categoryCode = :categoryCode and m.menuNameKo like concat('%', :query, '%')"
     )
     List<Menu> findByCategoryCodeAndMenuName(int categoryCode, String query);
+
 
     @Query(
 //   여기에 쿼리문 작성

--- a/CafeSync-FinalProject/src/main/java/com/ohgiraffers/cafesyncfinalproject/menu/model/entity/Menu.java
+++ b/CafeSync-FinalProject/src/main/java/com/ohgiraffers/cafesyncfinalproject/menu/model/entity/Menu.java
@@ -54,6 +54,6 @@ public class Menu {
         this.menuNameEN = menuDTO.getMenuNameEN();
         this.menuDetail = menuDTO.getMenuDetail();
         this.menuImage = menuDTO.getMenuImage();
+        this.disconStatus = menuDTO.getDisconStatus();  // 단종 여부도 업데이트
     }
-
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#159 

## 📝 요약(Summary)

- 본사 메뉴 관리 수정 및 단종 메뉴 기능 추가되었습니다
- 수정 시 메뉴 사진도 수정할 수 있게끔 변경했습니다 (이미지는 Firebase에 저장되도록 하였습니다)
- 단종 버튼 클릭 시 자동으로 단종 메뉴 페이지로 이동 됩니다 단종 메뉴는 솔드아웃으로 표현됩니다

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 메뉴 수정 성공
![image](https://github.com/user-attachments/assets/89563deb-a312-4238-ac12-de09669185a3)


## ✅ PR Checklist

PR 에 대해 확인 하였으면 본인 이름을 체크해주세요. 
<br>
📢 마지막에 체크한 팀원이 merge 버튼을 눌러주세요.

- [x] 정근희
- [x] 윤이정
- [x] 김용욱
- [x] 정승찬
